### PR TITLE
Update Metrics signature to match VolumeCreator interface

### DIFF
--- a/rootfs_provider/cakeordinator.go
+++ b/rootfs_provider/cakeordinator.go
@@ -70,7 +70,7 @@ func (c *CakeOrdinator) Create(logger lager.Logger, id string, spec Spec) (strin
 	return c.layerCreator.Create(logger, id, image, spec)
 }
 
-func (c *CakeOrdinator) Metrics(logger lager.Logger, id string) (garden.ContainerDiskStat, error) {
+func (c *CakeOrdinator) Metrics(logger lager.Logger, id, _ string) (garden.ContainerDiskStat, error) {
 	cid := layercake.ContainerID(id)
 	return c.metrics.Metrics(logger, cid)
 }

--- a/rootfs_provider/cakeordinator_test.go
+++ b/rootfs_provider/cakeordinator_test.go
@@ -115,7 +115,7 @@ var _ = Describe("The Cake Co-ordinator", func() {
 				TotalBytesUsed: 12,
 			}, nil)
 
-			metrics, err := cakeOrdinator.Metrics(logger, "something")
+			metrics, err := cakeOrdinator.Metrics(logger, "something", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			_, path := fakeMetrics.MetricsArgsForCall(0)
@@ -132,7 +132,7 @@ var _ = Describe("The Cake Co-ordinator", func() {
 			})
 
 			It("should return an error", func() {
-				_, err := cakeOrdinator.Metrics(logger, "something")
+				_, err := cakeOrdinator.Metrics(logger, "something", "")
 				Expect(err).To(MatchError("rotten banana"))
 			})
 		})


### PR DESCRIPTION
Update the `Metrics` method to match the new `VolumeCreator` interface

[#133928963]
Part of https://www.pivotaltracker.com/story/show/133928963

Signed-off-by: Tiago Scolari <tscolari@pivotal.io>